### PR TITLE
Ignore log4j log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .svn/
 bin/
 *.class
+
+\log4j.log


### PR DESCRIPTION
Currently log files are not ignored by git, which can lead to a lot of unnecessary commits
This pull request ignores log4j files
